### PR TITLE
DO NOT MERGE: Fixed so errors are properly constructed, but UNTESTED

### DIFF
--- a/lib/purview_api/resource/class_methods.rb
+++ b/lib/purview_api/resource/class_methods.rb
@@ -149,16 +149,16 @@ module PurviewApi
         begin
           error_info = JSON.load(body)
           if error_info.is_a?(Hash) and error_info['errors']
-            error_info['errors'].each {|field, messages| errors.add(field.to_sym, messages)}
+            error_info['errors'].each {|field, message| errors.add(field.to_sym, message)}
           else
-            errors.add(:base, ["unknown client error #{status}"])
+            errors.add(:base, "unknown client error #{status}")
           end
         rescue JSON::ParserError => e
-          errors.add(:base, ["unparseable client error #{status} #{e}"])
+          errors.add(:base, "unparseable client error #{status} #{e}")
         end
         true
       when 5
-        errors.add(:base, ["server error #{status}"])
+        errors.add(:base, "server error #{status}")
         true
       else
         false


### PR DESCRIPTION
This is WIP that I may not be able to attend to in the next day or two. If someone else can, that's great. If not, I'll pick it up when I can. The existing behavior is incorrect, but it's not currently causing problems because there's a workaround in UDE. However, getting rid of that workaround would be nice.

ActiveModelErrors#add was being called with an array containing a string when
it should have just been called with a string.  See
http://api.rubyonrails.org/classes/ActiveModel/Errors.html#method-i-add
for more info.

I have not yet verified that tests still pass with this mod, nor have
I added a new test, because currently my Purview development
environment isn't running, so I have no endpoint to use for testing (and
it's late in the day).