### PR TITLE
Fixed so errors are properly constructed.

### DIFF
--- a/lib/purview_api/resource/class_methods.rb
+++ b/lib/purview_api/resource/class_methods.rb
@@ -149,16 +149,16 @@ module PurviewApi
         begin
           error_info = JSON.load(body)
           if error_info.is_a?(Hash) and error_info['errors']
-            error_info['errors'].each {|field, messages| errors.add(field.to_sym, messages)}
+            error_info['errors'].each {|field, message| errors.add(field.to_sym, message)}
           else
-            errors.add(:base, ["unknown client error #{status}"])
+            errors.add(:base, "unknown client error #{status}")
           end
         rescue JSON::ParserError => e
-          errors.add(:base, ["unparseable client error #{status} #{e}"])
+          errors.add(:base, "unparseable client error #{status} #{e}")
         end
         true
       when 5
-        errors.add(:base, ["server error #{status}"])
+        errors.add(:base, "server error #{status}")
         true
       else
         false


### PR DESCRIPTION
ActiveModelErrors#add was being called with an array containing a string when
it should have just been called with a string.  See
http://api.rubyonrails.org/classes/ActiveModel/Errors.html#method-i-add
for more info.

I have verified that bin/rake still passes with this mod.

I have not added a new spec because this gem is already lacking
coverage and a spec would mostly be a feel-good exercise, because the
functionality that has been changed only makes a difference to a
client that is using this gem.

If this gem already had 100% coverage, I'd add a spec because having
100% coverage is like double-entry accounting; 100% provides
protection from a certain class of errors, but it's much less useful
if done incompletely.